### PR TITLE
Fixed initialization of tensor weights when #classes < #channels

### DIFF
--- a/template/setup.py
+++ b/template/setup.py
@@ -164,7 +164,8 @@ def _load_class_frequencies_weights_from_file(dataset_folder, inmem, workers):
         Class frequencies for the selected dataset, contained in the analytics.csv file.
     """
     csv_file = _load_analytics_csv(dataset_folder, inmem, workers)
-    return csv_file.ix[2, 1:].as_matrix().astype(float)
+    class_frequencies_weights = csv_file.ix[2, 1:].as_matrix().astype(float)
+    return class_frequencies_weights[np.logical_not(np.isnan(class_frequencies_weights))]
 
 
 def _get_optimizer(optimizer_name, model, **kwargs):


### PR DESCRIPTION
The tensor weights get initialized from the analytics.csv file which holds information about the RGB channels and class_frequencies. It gets the information by creating a matrix of all information and generates an array of the third row. This array will have as many elements as needed to accomodate all the rows in length. That leads to the error of initializing the class_frequencies array to at least 3 elements (since the RGB channels are always 3). The last element is a NaN and leads to the following error (when training on binary classification):

[   ERROR] --- Unhandled error: RuntimeError('weight tensor should be defined either for all 2 classes or no classes but got weight tensor of shape: [3] at /opt/conda/conda-bld/pytorch_1518241644131/work/torch/lib/THNN/generic/ClassNLLCriterion.c:30',) (RunMe.py:261)

This PR fixes the array by removing NaN values. It was testet with 2 and 10 classes on the MNIST dataset.