### PR TITLE
Triplet metric should be non-inverted

### DIFF
--- a/template/runner/triplet/triplet.py
+++ b/template/runner/triplet/triplet.py
@@ -127,7 +127,7 @@ class Triplet:
                                         model=model,
                                         optimizer=optimizer,
                                         log_dir=current_log_folder,
-                                        invert_best=True,
+                                        invert_best=False,
                                         checkpoint_all_epochs=checkpoint_all_epochs)
 
                 # Generate new triplets every N epochs


### PR DESCRIPTION
When using `invert_best=True` (before change) the best model checkpoint would not be created, instead you would only get the model of the last epoch.