### PR TITLE
Optimisation of mAP calculation

### DIFF
--- a/template/runner/triplet/evaluate.py
+++ b/template/runner/triplet/evaluate.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import logging
 import time
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import pairwise_distances_chunked
 import numpy as np
 
 # Torch related stuff
@@ -99,7 +99,7 @@ def _evaluate_map(data_loader, model, writer, epoch, logging_label, no_cuda, log
     outputs = np.concatenate(outputs, 0)
 
     # Cosine similarity distance
-    distances = pairwise_distances(outputs, metric='cosine', n_jobs=16)
+    distances = pairwise_distances_chunked(outputs, metric='cosine', n_jobs=16)
     logging.debug('Computed pairwise distances')
     logging.debug('Distance matrix shape: {}'.format(distances.shape))
     t = time.time()

--- a/util/evaluation/metrics/apk.py
+++ b/util/evaluation/metrics/apk.py
@@ -160,12 +160,17 @@ def compute_mapk(distances, labels, k, workers=None):
 
     # Fetch the index of the lowest `max_count` (k) elements
     t = time.time()
-    ind = np.argpartition(distances, max_count - 1)[:, :max_count]
-    # Find the sorting sequence according to the shortest distances selected from `ind`
-    ssd = np.argsort(np.array(distances)[np.arange(distances.shape[0])[:, None], ind], axis=1)
-    # Consequently sort `ind`
-    ind = ind[np.arange(ind.shape[0])[:, None], ssd]
-    # Now `ind` contains the sorted indexes of the lowest `max_count` (k) elements
+    if k != 'full':
+        ind = np.argpartition(distances, max_count - 1)[:, :max_count]
+        # Find the sorting sequence according to the shortest distances selected from `ind`
+        ssd = np.argsort(np.array(distances)[np.arange(distances.shape[0])[:, None], ind], axis=1)
+        # Consequently sort `ind`
+        ind = ind[np.arange(ind.shape[0])[:, None], ssd]
+        # Now `ind` contains the sorted indexes of the lowest `max_count` (k) elements
+    else:
+        # If we're in full mode, just do the sorting directly
+        ind = np.argsort(distances)
+
     # Resolve the labels of the elements referred by `ind`
     sorted_predictions = np.empty(shape=(max_count, max_count), dtype=np.int)
     for i, row in enumerate(ind):

--- a/util/evaluation/metrics/apk.py
+++ b/util/evaluation/metrics/apk.py
@@ -36,7 +36,7 @@ def apk(query, predicted, k='full'):
     assert (len(predicted) > 0)
 
     # Count the number of relevant items that could be retrieved
-    num_hits = predicted.count(query)
+    num_hits = np.sum(predicted == query)
     if num_hits == 0:
         return 0
 
@@ -67,8 +67,8 @@ def apk(query, predicted, k='full'):
     relevant = np.zeros(len(predicted))
 
     # Find all locations where the predicted value matches the query and vice-versa.
-    hit_locs = np.where(predicted == query)[0]
-    non_hit_locs = np.where(predicted != query)[0]
+    hit_locs = (predicted == query)
+    non_hit_locs = np.logical_not(hit_locs)
 
     # Set all `hit_locs` to be 1. [0,0,0,0,0,0] -> [0,1,0,1,0,1]
     relevant[hit_locs] = 1
@@ -167,7 +167,10 @@ def compute_mapk(distances, labels, k, workers=None):
     ind = ind[np.arange(ind.shape[0])[:, None], ssd]
     # Now `ind` contains the sorted indexes of the lowest `max_count` (k) elements
     # Resolve the labels of the elements referred by `ind`
-    sorted_predictions = [list(labels[row][1:]) for row in ind]
+    sorted_predictions = np.empty(shape=(max_count, max_count), dtype=np.int)
+    for i, row in enumerate(ind):
+            sorted_predictions[i, :] = labels[row][1:]
+
     logging.debug('Finished computing sorted predictions in {} seconds'
                   .format(datetime.timedelta(seconds=int(time.time() - t))))
 

--- a/util/evaluation/metrics/apk.py
+++ b/util/evaluation/metrics/apk.py
@@ -89,8 +89,9 @@ def mapk(query, predicted, k=None, workers=1):
     ----------
     query : list
         List of queries.
-    predicted : list of list
-        Predicted responses for each query.
+    predicted : list of list, or generator to list of lists
+        Predicted responses for each query. Supports chunking with slices in
+        the first dimension.
     k : str or int
         If int, cutoff for retrieval is set to `k`
         If str, 'full' means cutoff is til the end of predicted
@@ -111,6 +112,12 @@ def mapk(query, predicted, k=None, workers=1):
     dict{label, float}
         The per class mean averages precision @k
     """
+
+    # If distances come from pairwise_distances_chunked they must be flattened
+    # since apk operates on a per-row basis.
+    if type(predicted) is types.GeneratorType:
+        predicted = [row for nested in predicted for row in nested]
+
     results = np.array([apk(q, p, k) for q, p in zip(query, predicted)])
     per_class_mapk = {str(l): np.mean(np.array(results)[np.where(query == l)[0]]) for l in np.unique(query)}
     return np.mean(results), per_class_mapk
@@ -147,6 +154,49 @@ def compute_mapk(distances, labels, k, workers=None):
         The per class mean averages precision @k
     """
 
+    def chunked_sorting(distances):
+        '''Sorts a _chunked_ pairwise distance matrix.
+
+            Parameters
+            ----------
+            distances : generator of ndarray
+                A generator yielding numpy arrays containing pairwise
+                distances between a subset of all elements. Suitable for
+                combination with sklearn.metrics.pairwise_distances_chunked
+                which slices the matrix along the first dimenstion (i.e. one
+                can iterate over entire rows easily).
+
+            Returns
+            -------
+            A generator of sorted chunks of the input matrix.
+        '''
+        for i, chunk in enumerate(distances):
+            # Fetch the index of the lowest `max_count` (k) elements
+            if k != 'full':
+                ind = np.argpartition(chunk, max_count - 1)[:, :max_count]
+                # Find the sorting sequence according to the shortest chunk selected from `ind`
+                ssd = np.argsort(np.array(chunk)[np.arange(chunk.shape[0])[:, None], ind], axis=1)
+                # Consequently sort `ind`
+                ind = ind[np.arange(ind.shape[0])[:, None], ssd]
+                # Now `ind` contains the sorted indexes of the lowest `max_count` (k) elements
+            else:
+                # If we're in full mode, just to the sorting directly
+                ind = np.argsort(chunk)
+
+            # Resolve the labels of the elements referred by `ind`
+            # sorted_predictions = [list(labels[row][1:]) for row in ind]
+            sorted_predictions = np.empty(shape=(chunk.shape[0],
+                                                 chunk.shape[1]-1),
+                                          dtype=np.int)
+            for i, row in enumerate(ind):
+                sorted_predictions[i, :] = labels[row][1:]
+
+            yield sorted_predictions
+
+    # In case of non-chunked input we wrap to ensure uniform treatment
+    if type(distances) is not types.GeneratorType:
+        distances = [distances]
+
     # Resolve k
     k = k if k == 'auto' or k == 'full' else int(k)
 
@@ -158,28 +208,10 @@ def compute_mapk(distances, labels, k, workers=None):
         # Take the highest frequency in the labels i.e. the highest possible 'auto' value for all entries
         max_count = np.max(np.unique(labels, return_counts=True)[1])
 
-    # Fetch the index of the lowest `max_count` (k) elements
-    t = time.time()
-    if k != 'full':
-        ind = np.argpartition(distances, max_count - 1)[:, :max_count]
-        # Find the sorting sequence according to the shortest distances selected from `ind`
-        ssd = np.argsort(np.array(distances)[np.arange(distances.shape[0])[:, None], ind], axis=1)
-        # Consequently sort `ind`
-        ind = ind[np.arange(ind.shape[0])[:, None], ssd]
-        # Now `ind` contains the sorted indexes of the lowest `max_count` (k) elements
-    else:
-        # If we're in full mode, just do the sorting directly
-        ind = np.argsort(distances)
-
-    # Resolve the labels of the elements referred by `ind`
-    sorted_predictions = np.empty(shape=(max_count, max_count), dtype=np.int)
-    for i, row in enumerate(ind):
-            sorted_predictions[i, :] = labels[row][1:]
-
-    logging.debug('Finished computing sorted predictions in {} seconds'
-                  .format(datetime.timedelta(seconds=int(time.time() - t))))
+    # Do lazy sorting of the distance matrix
+    sorted_predictions_chunked = chunked_sorting(distances)
 
     if workers is None:
         workers = 16 if k == 'auto' or k == 'full' else 1
 
-    return mapk(labels, sorted_predictions, k, workers)
+    return mapk(labels, sorted_predictions_chunked, k, workers)


### PR DESCRIPTION
Running the original implementation on a large dataset (>32k entries) had 2 problems:

1. Slow
2. Crashes with out of memory

I.e. It took a really long time for the program to fail. This PR solves (2) by chunking the input matrix in to chunks that can fit in memory (this is done with `sklearn.metrics.pairwise_distances_chunked`). The PR addresses (1) by pre-allocating the sorted prediction values (part of a critical loop previously using dynamic allocation).

In addition the chunking provides a slight performance increase with large matrices (at least those tested). This is probably due to better memory layout for caching.

The implementation has been tested for correctness outside of DeepDIVA. The modified version returns the same results as the original for random matrices. Code used for benchmarking and output validation:
```python3
imoprt numpy as np
import sklearn.metrics

from deepdiva.util import metrics as orig

def bench(N=4096, mode='chunked'):
    allowed_modes = ['chunked', 'contiguous', 'original']
    if mode not in allowed_modes:
        raise ValueError(f'Invalid mode {mode}. Must be one of {allowed_modes}')
    if type(N) is not list:
        N = [N]
    ret = []
    for el in N:
        X = np.random.random(size=(el, 3))
        if mode == 'chunked':
            distances = sklearn.metrics.pairwise_distances_chunked(X)
        else:
            distances = sklearn.metrics.pairwise_distances(X)
        labels = np.random.choice(range(10), size=(el,))

        now = time.time()
        if mode in ['chunked', 'contiguous']:
            score, _ = compute_mapk(distances, labels, k='full')
        else:
            score, _ = orig.compute_mapk(distances, labels, k='full')
        end = time.time() - now
        ret.append([end, score])
    return ret
```

The code above was used to produce the following benchmark plots. Do note that the original implementation crashed for an input size of `N=32768`. Both plots show exactly the same data, one in log-log scale and the other without.

The plots compares the original implementation to the two now allowed modes: chunking and contiguous where the latter uses only pre-allocation of arrays and the former additionally uses the chunking of the distance matrix.

The benchmarks were run on my local laptop (w/ 3 GHz Intel Core i7 and 8 GB 1600 MHz DDR3).

![loglog](https://user-images.githubusercontent.com/2122457/65537779-31370d00-df06-11e9-93aa-e36943f24d9c.png)

![standard](https://user-images.githubusercontent.com/2122457/65538873-9429a380-df08-11e9-8d2c-b17b686e5446.png)
