### PR TITLE
Update triplets after regeneration

### DIFF
--- a/template/runner/triplet/triplet.py
+++ b/template/runner/triplet/triplet.py
@@ -132,7 +132,7 @@ class Triplet:
 
                 # Generate new triplets every N epochs
                 if epoch % regenerate_every == 0:
-                    train_loader.dataset.generate_triplets()
+                    train_loader.triplets = train_loader.dataset.generate_triplets()
             logging.info('Training completed')
 
         # Test


### PR DESCRIPTION
I suspect that, while triplets are regenerated here, they are not updated in the dataset. Looking at how this case is handled initially 
https://github.com/DIVA-DIA/DeepDIVA/blob/4dccf3b5fab5d45abd09977f37079f1803520988/datasets/image_folder_triplet.py#L138
and at the function `generate_triplets`
https://github.com/DIVA-DIA/DeepDIVA/blob/4dccf3b5fab5d45abd09977f37079f1803520988/datasets/image_folder_triplet.py#L145
we see that this function only creates a new set, it never assigns to `self.triplets`.

Another idea would be to change the semantics of `generate_triplets` to modify the underlying instance (or create a helper `regenerate_triplets` for this purpose).