### PR TITLE
Fix triplet.py runtime errors

### DIFF
--- a/template/runner/triplet/evaluate.py
+++ b/template/runner/triplet/evaluate.py
@@ -101,7 +101,6 @@ def _evaluate_map(data_loader, model, writer, epoch, logging_label, no_cuda, log
     # Cosine similarity distance
     distances = pairwise_distances_chunked(outputs, metric='cosine', n_jobs=16)
     logging.debug('Computed pairwise distances')
-    logging.debug('Distance matrix shape: {}'.format(distances.shape))
     t = time.time()
     mAP, per_class_mAP = compute_mapk(distances, labels, k=map)
     writer.add_text('Per class mAP at epoch {}\n'.format(epoch),

--- a/template/runner/triplet/triplet.py
+++ b/template/runner/triplet/triplet.py
@@ -103,7 +103,7 @@ class Triplet:
 
             logging.info('Begin training')
             Triplet._validate(val_loader, model, writer, -1, **kwargs)
-            for epoch in range(start_epoch, epochs):
+            for epoch in range(epochs):
                 # Train
                 train_value[epoch] = Triplet._train(train_loader=train_loader,
                                                     model=model,

--- a/template/runner/triplet/triplet.py
+++ b/template/runner/triplet/triplet.py
@@ -102,7 +102,7 @@ class Triplet:
             # Core routine
 
             logging.info('Begin training')
-            Triplet._validate(val_loader, model, None, writer, -1, **kwargs)
+            Triplet._validate(val_loader, model, writer, -1, **kwargs)
             for epoch in range(start_epoch, epochs):
                 # Train
                 train_value[epoch] = Triplet._train(train_loader=train_loader,

--- a/template/runner/triplet/triplet.py
+++ b/template/runner/triplet/triplet.py
@@ -88,15 +88,15 @@ class Triplet:
                 **kwargs)
 
         # Setting up model, optimizer, criterion
-        model, _, optimizer, best_value, start_epoch = set_up_model(model_name=model_name,
-                                                                    lr=lr,
-                                                                    **kwargs)
+        model, _, optimizer, best_value = set_up_model(model_name=model_name,
+                                                       lr=lr,
+                                                       **kwargs)
 
         # Set the special criterion for triplets
         criterion = nn.TripletMarginLoss(margin=margin, swap=anchor_swap)
 
-        train_value = np.zeros((epochs - start_epoch))
-        val_value = np.zeros((epochs - start_epoch))
+        train_value = np.zeros(epochs)
+        val_value = np.zeros(epochs)
 
         if not only_evaluate:
             # Core routine

--- a/util/evaluation/metrics/apk.py
+++ b/util/evaluation/metrics/apk.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 import time
+import types
 import numpy as np
 
 


### PR DESCRIPTION
- Since commit 9a28991864ce55d63c0403a306e52c9aa92531fc `start_epoch` is not output by `template.set_up_model`.
- Remove extraneous parameter passed to `_validate`.
- Bugfixes from PR #014